### PR TITLE
Update install-console.md

### DIFF
--- a/SystemCenterDocs/vmm/install-console.md
+++ b/SystemCenterDocs/vmm/install-console.md
@@ -76,20 +76,20 @@ ProgramFiles | Specify the location in which to store program files.
 IndigoTCpPort | Specify the port number used to communicate with the VMM server.
 MUOptIn | 0: Don't opt in to Microsoft Update. 1: Opt in.
 VmmServerForOpsMgrConfig | Specify the name of the System Center Operations Manager server.
-IACCEPTSCUELA | Specifies that you have read, understood, and accepted the terms of use.
 
 Install the console as follows:
 
 1. Copy the VMClient.ini file from the amd64\Setup folder to a local folder.
 2. Edit the VMClient.ini file. Remove the comment indicator (#) only if you want to edit the entry. Otherwise, setup uses the values in the .ini file as the default values.
-3. Run setup as follows: setup.exe /client /i /f \<path\>, where:
+3. Run setup as follows: setup.exe /client /i /IACCEPTSCEULA /f \<path\>, where:
    - /client - specifies console installation
    - /i or /x - specify whether to install (/i) or uninstall (/x) the console.
+   - /IACCEPTSCEULA - Specifies that you have read, understood, and accepted the terms of use.
    - /f &lt;filename&gt; - specifies the ini file to use. Make sure this is correct. If setup doesn't find the ini file, it installs with default values.
    - path: location of ini file.
    - Don't use the /opsmgr parameter
 
-Example: **setup.exe /client /i /f C:\Temp\VMClient.ini**.
+Example: **setup.exe /client /i /IACCEPTSCEULA /f C:\Temp\VMClient.ini**.
 
 ## Connect to a VMM management server
 


### PR DESCRIPTION
/IACCEPTSCEULA does not have correct spelling and is only valid in the command line, not within VMCLIENT.INI file.

If the value is entered into the VMCLIENT.INI file, you will get an installation error saying "Have NOT acknowledge acceptance of the license terms in unattended install."