### PR TITLE
Update plan-security-tls12-config.md

### DIFF
--- a/SystemCenterDocs/scom/plan-security-tls12-config.md
+++ b/SystemCenterDocs/scom/plan-security-tls12-config.md
@@ -152,6 +152,7 @@ foreach ($Protocol in $ProtocolList)
     New-ItemProperty -Path $currentRegPath -Name 'Enabled' -Value "0" -PropertyType DWORD -Force | Out-Null
   }
   Write-Output " "
+ }
 }
 ```
 


### PR DESCRIPTION
The script "Method 2: Modify the registry with PowerShell" was missing a closing "}" [curly bracket]. This has been added