### PR TITLE
Update deploy-install-web-console.md | Corrections for calrity

### DIFF
--- a/SystemCenterDocs/scom/deploy-install-web-console.md
+++ b/SystemCenterDocs/scom/deploy-install-web-console.md
@@ -152,8 +152,8 @@ The local and remote parameters are as follows:
 5. On the **Prerequisites** page, review and address any warnings or errors, and select **Verify Prerequisites Again** to recheck the system.
 
     > [!NOTE]
-    >- Installation of the System Center - Operations Manager web console requires that ISAPI and CGI Restrictions in IIS be enabled for ASP.NET 4. To enable this, select the web server in IIS Manager, and then double-click **ISAPI and CGI Restrictions**. Select **ASP.NET v4.0.30319**, and select **Allow**.
-    >- Select **ASP.NET v4.8**, and select **Allow** (applicable for Operations Manager 2022).
+    >- Installation of the System Center - Operations Manager web console requires that ISAPI and CGI Restrictions in IIS be enabled for ASP.NET 4. To enable this, select the web server in IIS Manager, and then double-click **ISAPI and CGI Restrictions**. Select **ASP.NET v4.0.30319** (for SCOM 2016 and SCOM 2019), and select **Allow**.
+    >- For SCOM 2022 and newer: Select **ASP.NET v4.8**, and select **Allow**.
 
 6. If the Prerequisite checker returns no warnings or errors, the **Prerequisites**, **Proceed with Setup** page appears. Select **Next**.
 


### PR DESCRIPTION
The guidance indicates that ISAPI/CGI restrictions must be enabled for ASP.NET (v4.x)  However:
- It mixes ASP.NET v4.0.30319 (older) and v4.8 (SCOM 2022) in one note for all site version (SCOM 2016, SCOM 2019, SCOM 2022 and SCOM 2025).
- Doesn't clarify if both must be enabled (for overlapping scenarios), or if one supersedes the other on newer servers.
Suggestion: Cleanly list IIS prerequisites per SCOM version (e.g., "For SCOM 2022 and newer: enable ASP.NET 4.8; for earlier: ASP.NET 4.0.30319").