### PR TITLE
Unnecessary or awkward dash in product name

### DIFF
--- a/SystemCenterDocs/scom/deploy-install-web-console.md
+++ b/SystemCenterDocs/scom/deploy-install-web-console.md
@@ -13,7 +13,7 @@ ms.topic: install-set-up-deploy
 
 # Install the Operations Manager Web console
 
-You can install the web console when you install System Center - Operations Manager, or you can install it separately. You can install a stand-alone web console or install it on an existing management server that meets the prerequisites.
+You can install the web console when you install System Center Operations Manager, or you can install it separately. You can install a stand-alone web console or install it on an existing management server that meets the prerequisites.
 
 [!INCLUDE [ntauthority-note-operations-manager.md](../includes/ntauthority-note-operations-manager.md)]
 


### PR DESCRIPTION
The article repeatedly uses "System Center - Operations Manager" with a dash (e.g., in the opening sentence). The official product name is "System Center Operations Manager" without the dash, which makes this punctuation feel misplaced or like an en-dash error. It should be removed for standard branding.