### PR TITLE
Update SSL parameter name in web console installation

### DIFF
--- a/SystemCenterDocs/scom/deploy-install-web-console.md
+++ b/SystemCenterDocs/scom/deploy-install-web-console.md
@@ -181,7 +181,7 @@ The local and remote parameters are as follows:
 3. Change the path to where the Operations Manager setup.exe file is located, and run the following command.
 
     > [!IMPORTANT]
-    > Use the `/WebConsoleSSL` parameter only if your website has Secure Sockets Layer (SSL) activated.
+    > Use the `/WebConsoleUseSSL` parameter only if your website has Secure Sockets Layer (SSL) activated.
     >
     > For a default web installation, specify **Default Web Site** for the `/WebSiteName` parameter.
 


### PR DESCRIPTION
The "Important" note under the command-line installation section incorrectly refers to the parameter as /WebConsoleSSL (exact quote: "Use the /WebConsoleSSL parameter only if your website has Secure Sockets Layer (SSL) activated."). However, the actual syntax block and correct parameter name is /WebConsoleUseSSL. This mismatch could result in command failures if users rely on the note alone, as the installer won't recognize the shortened version. Fix: Update the note to use “/WebConsoleUseSSL” consistently