### PR TITLE
Corercted many inacuraccies (grammar, style, wording, duplication)

### DIFF
--- a/SystemCenterDocs/scom/deploy-install-web-console.md
+++ b/SystemCenterDocs/scom/deploy-install-web-console.md
@@ -40,7 +40,7 @@ Installation of Reporting and Web Console will be successful, regardless of the 
  For information about the prerequisites, see [System Requirements for System Center Operations Manager](./system-requirements.md).
 
 > [!IMPORTANT]
-> If you install a standalone web console on a server, you won't be able to add the management server feature to this server. If you want to install the management server and web console on the same server, you must either install both features simultaneously or install the management server before you install the web console.
+> If you install a stand-alone web console on a server, you won't be able to add the management server feature to this server. If you want to install the management server and web console on the same server, you must either install both features simultaneously or install the management server before you install the web console.
 
 When you install the web console, the following three components are installed:
 
@@ -119,7 +119,7 @@ The local and remote parameters are as follows:
 
 7. On the **Configuration**, **Please read the license terms** page, review the Microsoft Software License Terms, select **I have read, understood and agree with the license terms**, and select **Next**.
 
-8. On the **Configuration**, **Specify a management server** page, enter the name of a management server that only the web console uses, and select **Next**.
+8. On the **Configuration**, **Specify a management server** page, enter the name of a management server in the management group, and select **Next**.
 
 9. On the **Configuration**, **Specify a web site for use with the Web console** page, select the **Default Web Site**, or the name of an existing website. Select **Enable SSL** only if the website has been configured to use Secure Sockets Layer (SSL), and select **Next**.
 
@@ -129,7 +129,7 @@ The local and remote parameters are as follows:
 10. On the **Configuration**, **Select an authentication mode for use with the Web console** page, select your option, and select **Next**.
 
     > [!NOTE]
-    > If you install the management server on a server using a domain account for System Center Configuration service and System Center Data Access service, and then install the web console on a different server and select Mixed Authentication, you may need to register Service Principle Names and configure constraint delegations, as described in [Running the Web Console Server on a standalone server using Windows Authentication](/troubleshoot/system-center/scom/http-500-error-connecting-to-web-console).
+    > If you install the management server on a server using a domain account for System Center Configuration service and System Center Data Access service, and then install the web console on a different server and select Mixed Authentication, you may need to register Service Principal Names and configure constraint delegations, as described in [Running the Web Console Server on a stand-alone server using Windows Authentication](/troubleshoot/system-center/scom/http-500-error-connecting-to-web-console).
 
 11. On the **Diagnostic and Usage Data** page, review data collection terms and then select **Next** to continue.  
 
@@ -170,7 +170,7 @@ The local and remote parameters are as follows:
 12. On the **Setup is complete** page, select **Close**.
 
 > [!IMPORTANT]
-> The Default website must have an http or https binding configured. If you configure a specific IP address or host header in the bindings of the web console website, create additional bindings on the website for the same ports by using the loopback address or the localhost hostname, depending on the scenario. For more information, see [Host header or IP address binding causes web console login errors in Operations Manager](/troubleshoot/system-center/scom/web-console-login-errors).
+> The **Default Web Site** must have an http or https binding configured. If you configure a specific IP address or host header in the bindings of the web console website, create additional bindings on the website for the same ports by using the loopback address or the localhost hostname, depending on the scenario. For more information, see [Host header or IP address binding causes web console login errors in Operations Manager](/troubleshoot/system-center/scom/web-console-login-errors).
 
 ### Install a Web console by using the Command Prompt window
 


### PR DESCRIPTION
1. "Service Principle Names" → should be Service Principal Names (SPNs). Also "constraint delegations” → constrained delegation. Microsoft Learn Fix: Correct terminology: "register Service Principal Names (SPNs) and configure constrained delegation …".

2. "The Default website must have an http or https binding …" — the IIS object is "Default Web Site". Precision matters for readers following UI literally. 

3. Clarity tweak ("management server that only the web console uses") Problem: Reads as if a dedicated management server is required. Not strictly true; it just needs a management server in the MG.  Fix: "Enter the name of a management server in the management group."

4. Inconsistent hyphenation (stand-alone: The term "stand-alone" is hyphenated in "You can install a stand-alone web console," but appears without a hyphen as "standalone" in "If you install a standalone web console on a server." Standard English usage prefers consistency (e.g., always "stand-alone" as an adjective modifying "web console").