### PR TITLE
Typo in SYSTEM account name

### DIFF
--- a/SystemCenterDocs/includes/ntauthority-note-operations-manager.md
+++ b/SystemCenterDocs/includes/ntauthority-note-operations-manager.md
@@ -11,4 +11,4 @@ ms.subservice: operations-manager
 ---
 
 >[!NOTE]
-> We recommend that you don't use the **NTAuthority\SYSTEM** user for the installation of System Center Operations Manager.
+> We recommend that you don't use the **NT Authority\SYSTEM** user for the installation of System Center Operations Manager.


### PR DESCRIPTION
In the note "We recommend that you don't use the NTAuthority\SYSTEM user for the installation of System Center Operations Manager," "NTAuthority\SYSTEM" is missing a space and should be "**NT AUTHORITY\SYSTEM.**" This is a common Windows account reference, and the error could confuse readers unfamiliar with the exact naming.